### PR TITLE
feat(note): make note title optional

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -49,15 +49,16 @@ class NoteController extends Controller
         $this->validate(
             $request,
             [
-                'title' => 'required',
+                'title' => 'max:80',
                 'content' => 'required',
             ]
         );
 
+        $requestBody = $request->all();
         $note = new Note();
         $note->user_id = JWTAuth::parseToken()->toUser()->id;
-        $note->title = $request['title'];
-        $note->content = $request['content'];
+        $note->title = $requestBody['title'] ?? '';
+        $note->content = $requestBody['content'];
 
         $note->save();
 


### PR DESCRIPTION
### What this PR Does.

Previously, the title of a note is required. This is a bad ux as it does not allow a user to create notes without titles. This limits users from creating notes on the fly

### How to manually test this feature?
Provided you're signed in and your authorisation header is set,
#####  Request
 `POST localhost:<app-port>/users/note`
###### Payload 
{"content": "this is a content. it does not have a title"}
#### Expected Response

```
{
    "user_id": <current user id>,
    "title": ""
    "content": "this is a content. it does not have a title",
    "createdAt": <"yyyy-mm-dd hh-mm-ss">
    "updatedAt":  <"yyyy-mm-dd hh-mm-ss">
    "id": 2
}

```